### PR TITLE
global shift register

### DIFF
--- a/shift_register.py
+++ b/shift_register.py
@@ -47,7 +47,7 @@ class ShiftRegister:
             if num > 0:
                 args += [f'.dst{col}(dst{col})']
         arg = indent(level + 2) + f',\n{indent(level+2)}'.join(args)
-        return indent(level) + f'compressor compressor(\n{arg});\n'
+        return indent(level) + f'{self.name} {self.name}(\n{arg});\n'
 
     def gen_initial_block(self, level):
         code = indent(level) + 'initial begin\n'


### PR DESCRIPTION
あらゆるコンプレッサで使えるシフトレジスタモジュール

コンストラクタは入力段と出力段の形状を取る

入力の各列を  1 本のシフトレジスタで供給する

モジュールの引数はクロック、各列のシフトレジスタの入力、出力段のすべてのワイヤ